### PR TITLE
fix profile modifiers and high scores

### DIFF
--- a/ProfileManager/profileManager.go
+++ b/ProfileManager/profileManager.go
@@ -201,6 +201,7 @@ func (pm *ProfileManager) PutScoreBoard(sb proto.ScoreBoardPacket) {
 		p.Kcal += sb.Kcal
 
 		v.Profile = p
+		pm.loadedProfiles[accessCode] = v
 		err := pm.sb.SaveProfile(p)
 		if err != nil {
 			log.Error("Error saving %s profile: %s", p.Nickname, err)
@@ -226,8 +227,33 @@ func (pm *ProfileManager) PutScoreBoard2(sb proto.ScoreBoardPacket2) {
 		p.PP += uint64(sb.PP)
 		p.RunningStep += uint64(sb.RunningStep)
 		p.Kcal += sb.Kcal
+		p.Modifiers = uint64(sb.Modifiers)
+		p.NoteSkinSpeed = sb.NoteSkinSpeed
+		p.RushSpeed = sb.RushSpeed
+		for i := 0; i < len(p.Scores); i++ {
+			score := &p.Scores[i]
+			if score.SongID != 0 {
+				if score.SongID != sb.SongID {
+					continue
+				}
+				if score.ChartLevel != uint8(sb.ChartLevel) {
+					continue
+				}
+			}
+			if score.Score <= sb.Score {
+				score.SongID = sb.SongID
+				score.ChartLevel = uint8(sb.ChartLevel)
+				score.Unk0 = 0
+				score.GameDataFlag = 0
+				score.Score = sb.Score
+				score.RealScore = sb.Score
+				score.Unk2 = 1
+			}
+			break
+		}
 
 		v.Profile = p
+		pm.loadedProfiles[accessCode] = v
 		err := pm.sb.SaveProfile(p)
 		if err != nil {
 			log.Error("Error saving %s profile: %s", p.Nickname, err)

--- a/ProfileManager/profileManager_test.go
+++ b/ProfileManager/profileManager_test.go
@@ -1,0 +1,157 @@
+package ProfileManager
+
+import (
+	"github.com/HUEBRTeam/PrimeServer/proto"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type FakeProfileStorageBackend struct {
+}
+
+func (ps *FakeProfileStorageBackend) GetProfile(accessCode string) (proto.ProfilePacket, error) {
+	return proto.ProfilePacket{}, nil
+}
+func (ps *FakeProfileStorageBackend) CreateProfile(name string, country int, avatar int, modifiers int, noteskinspeed int) (proto.ProfilePacket, error) {
+	return proto.ProfilePacket{}, nil
+}
+func (ps *FakeProfileStorageBackend) SaveProfile(packet proto.ProfilePacket) error  { return nil }
+func (ps *FakeProfileStorageBackend) SaveWorldBest(wb *proto.WorldBestPacket) error { return nil }
+func (ps *FakeProfileStorageBackend) SaveRankMode(rm *proto.RankModePacket) error   { return nil }
+func (ps *FakeProfileStorageBackend) GetWorldBest() (wb *proto.WorldBestPacket, err error) {
+	return &proto.WorldBestPacket{}, nil
+}
+func (ps *FakeProfileStorageBackend) GetRankMode() (rm *proto.RankModePacket, err error) {
+	return &proto.RankModePacket{}, nil
+}
+func (ps *FakeProfileStorageBackend) GetFolder() string { return "" }
+
+func TestProfileManager_PutScoreBoard2(t *testing.T) {
+	const accessCode = "fake-access-code"
+	profile := proto.ProfilePacket{
+		ProfileID: uint32(1),
+	}
+	profile.Scores[0] = proto.UScore{
+		SongID:     123,
+		ChartLevel: 1,
+		Score:      5000,
+		Unk2:       1,
+	}
+
+	pm := &ProfileManager{
+		sb: &FakeProfileStorageBackend{},
+		profileIdToAccessCode: map[uint32]string{
+			profile.ProfileID: accessCode,
+		},
+		loadedProfiles: map[string]ProfileSession{
+			"fake-access-code": {
+				Profile: profile,
+			},
+		},
+	}
+
+	t.Run("when profile plays a new song, add a new score entry", func(t *testing.T) {
+		pm.loadedProfiles[accessCode] = ProfileSession{
+			Profile: profile,
+		}
+		pm.PutScoreBoard2(proto.ScoreBoardPacket2{
+			ProfileID:  profile.ProfileID,
+			SongID:     456,
+			ChartLevel: 2,
+			Score:      10000,
+		})
+
+		p := pm.loadedProfiles[accessCode].Profile
+		t.Run("existing scores remain unchanged", func(t *testing.T) {
+			require.Equal(t, uint32(123), p.Scores[0].SongID)
+			require.Equal(t, uint8(1), p.Scores[0].ChartLevel)
+			require.Equal(t, uint32(5000), p.Scores[0].Score)
+		})
+		t.Run("add a new score entry", func(t *testing.T) {
+			require.Equal(t, uint32(456), p.Scores[1].SongID)
+			require.Equal(t, uint8(2), p.Scores[1].ChartLevel)
+			require.Equal(t, uint32(10000), p.Scores[1].Score)
+			require.Equal(t, uint32(1), p.Scores[1].Unk2)
+		})
+		t.Run("do not overflow", func(t *testing.T) {
+			require.Equal(t, uint32(0), p.Scores[2].SongID)
+			require.Equal(t, uint8(0), p.Scores[2].ChartLevel)
+			require.Equal(t, uint32(0), p.Scores[2].Score)
+		})
+	})
+	t.Run("when profile plays the same song but on a different chart level", func(t *testing.T) {
+		pm.loadedProfiles[accessCode] = ProfileSession{
+			Profile: profile,
+		}
+		pm.PutScoreBoard2(proto.ScoreBoardPacket2{
+			ProfileID:  profile.ProfileID,
+			SongID:     123,
+			ChartLevel: 2,
+			Score:      10000,
+		})
+
+		p := pm.loadedProfiles[accessCode].Profile
+		t.Run("existing scores remain unchanged", func(t *testing.T) {
+			require.Equal(t, uint32(123), p.Scores[0].SongID)
+			require.Equal(t, uint8(1), p.Scores[0].ChartLevel)
+			require.Equal(t, uint32(5000), p.Scores[0].Score)
+		})
+		t.Run("add a new score entry", func(t *testing.T) {
+			require.Equal(t, uint32(123), p.Scores[1].SongID)
+			require.Equal(t, uint8(2), p.Scores[1].ChartLevel)
+			require.Equal(t, uint32(10000), p.Scores[1].Score)
+			require.Equal(t, uint32(1), p.Scores[1].Unk2)
+		})
+		t.Run("do not overflow", func(t *testing.T) {
+			require.Equal(t, uint32(0), p.Scores[2].SongID)
+			require.Equal(t, uint8(0), p.Scores[2].ChartLevel)
+			require.Equal(t, uint32(0), p.Scores[2].Score)
+		})
+	})
+	t.Run("when profile plays the same song and same chart level with a higher score", func(t *testing.T) {
+		pm.loadedProfiles[accessCode] = ProfileSession{
+			Profile: profile,
+		}
+		pm.PutScoreBoard2(proto.ScoreBoardPacket2{
+			ProfileID:  profile.ProfileID,
+			SongID:     123,
+			ChartLevel: 1,
+			Score:      10000,
+		})
+
+		p := pm.loadedProfiles[accessCode].Profile
+		t.Run("replace the existing score with the new high score", func(t *testing.T) {
+			require.Equal(t, uint32(123), p.Scores[0].SongID)
+			require.Equal(t, uint8(1), p.Scores[0].ChartLevel)
+			require.Equal(t, uint32(10000), p.Scores[0].Score)
+		})
+		t.Run("do not overflow", func(t *testing.T) {
+			require.Equal(t, uint32(0), p.Scores[1].SongID)
+			require.Equal(t, uint8(0), p.Scores[1].ChartLevel)
+			require.Equal(t, uint32(0), p.Scores[1].Score)
+		})
+	})
+	t.Run("when profile plays the same song and same chart level with a lower score", func(t *testing.T) {
+		pm.loadedProfiles[accessCode] = ProfileSession{
+			Profile: profile,
+		}
+		pm.PutScoreBoard2(proto.ScoreBoardPacket2{
+			ProfileID:  profile.ProfileID,
+			SongID:     123,
+			ChartLevel: 1,
+			Score:      2000,
+		})
+
+		p := pm.loadedProfiles[accessCode].Profile
+		t.Run("do not register it to maintain the existing higher score", func(t *testing.T) {
+			require.Equal(t, uint32(123), p.Scores[0].SongID)
+			require.Equal(t, uint8(1), p.Scores[0].ChartLevel)
+			require.Equal(t, uint32(5000), p.Scores[0].Score)
+		})
+		t.Run("do not overflow", func(t *testing.T) {
+			require.Equal(t, uint32(0), p.Scores[1].SongID)
+			require.Equal(t, uint8(0), p.Scores[1].ChartLevel)
+			require.Equal(t, uint32(0), p.Scores[1].Score)
+		})
+	})
+}


### PR DESCRIPTION
Fixes a few issues that prevented to correctly update certain profile fields such as modifiers, rush settings, note skins and high scores. For `proto.UScore` the field `Unk2` is set to `1` to unflag the chart as "new".